### PR TITLE
Fix visuals, braces after LaTeX command

### DIFF
--- a/chapters/chapter03.tex
+++ b/chapters/chapter03.tex
@@ -196,7 +196,7 @@
                 \node<4->[above=0cm of compile]{latexmk <datei.tex>};
                 \node<6->[above=0cm of output]{*.pdf/*.dvi/*.ps};
             \end{tikzpicture}
-            \caption{Kompilieren mit \LaTeX}
+            \caption{Kompilieren mit \LaTeX{}}
         \end{figure}
         \begin{itemize}
             \item<7-> In der Praxis klickt man meistens auf einen Button in der IDE
@@ -486,7 +486,7 @@
         \end{columns}
     \end{frame}
 
-    \subsection{Mit \LaTeX arbeiten}
+    \subsection{Mit \LaTeX{} arbeiten}
     \urlslide[Sharelatex-Instanz der TU-Darmstadt(langsam, nicht empfohlen)]{https://sharelatex.tu-darmstadt.de}
     \urlslide[Beispielprojekt]{https://github.com/Rdeisenroth/LaTeX-Workshop-Workspace-Template}
     % \urlslide[Coder-Instanz der Tudalgo(schneller, empfohlen falls nicht lokal installiert)]{https://coder-ophase.ruben-deisenroth.de}


### PR DESCRIPTION
A simple visual fix for the spacing after the `\LaTeX` command in chapter 03